### PR TITLE
Blank viz bugfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Report Table for Looker
+# Report Table for Looker.
 
 A table dedicated to single-page, enterprise summary reports. Useful for PDF exports, report packs, finance reporting, etc. Does not do multi-page tables and lists. Does look good for your year-on-year analysis. Originally created by [Jon Walls](https://github.com/ContrastingSounds/vis-report_table).
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Report Table for Looker.
+# Report Table for Looker
 
 A table dedicated to single-page, enterprise summary reports. Useful for PDF exports, report packs, finance reporting, etc. Does not do multi-page tables and lists. Does look good for your year-on-year analysis. Originally created by [Jon Walls](https://github.com/ContrastingSounds/vis-report_table).
 

--- a/src/vis_table_plugin.js
+++ b/src/vis_table_plugin.js
@@ -1729,12 +1729,12 @@ class VisPluginTableModel {
     return function(a, b) {
       var depth = Math.max(a.sort.length, b.sort.length)
       for (var i = 0; i < depth; i++) {
-          var field = typeof a.sort[i].name !== 'undefined' ? a.sort[i].name : ''
+          var field = (a.sort[i] && typeof a.sort[i].name !== 'undefined') ? a.sort[i].name : ''
           var sort = dataTable.sorts.find(item => item.name === field)
           var desc = typeof sort !== 'undefined' ? sort.desc : false
 
-          var a_value = typeof a.sort[i] !== 'undefined' ? a.sort[i].value : 0
-          var b_value = typeof b.sort[i] !== 'undefined' ? b.sort[i].value : 0
+          var a_value = (a.sort[i] && typeof a.sort[i] !== 'undefined') ? a.sort[i].value : 0
+          var b_value = (b.sort[i] && typeof b.sort[i] !== 'undefined') ? b.sort[i].value : 0
 
           if (desc) {
             if (a_value < b_value) { return 1 }


### PR DESCRIPTION
In Firefox using comparisons would sometimes break table viz if datasets were not the same length. Here are some screenshots of the viz working with comparisons in firefox and chrome.
<img width="1316" alt="Screen Shot 2022-05-12 at 12 47 03 PM" src="https://user-images.githubusercontent.com/3744638/168157897-4c4833ec-55fb-47cf-82aa-cc9c4b4fcb59.png">
<img width="1019" alt="Screen Shot 2022-05-12 at 12 47 30 PM" src="https://user-images.githubusercontent.com/3744638/168157903-b8aa2584-35e3-466d-b7db-fc958dab114f.png">
 