### PR TITLE
feat: add `.editorconfig` for all code editors

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+insert_final_newline = true
+trim_trailing_whitespace = true


### PR DESCRIPTION
feat: add `.editorconfig` for all code editors

Contributions to our code should use standardized formatting and
configuration based on the Google TypeScript style guide. The
`.editorconfig` file has been generated using `npx gts init`. GTS is
Google's TypeScript formatter, fixer, and linter found at
https://github.com/google/gts.

More information about editorconfig can be found at
https://editorconfig.org.

