### PR TITLE
Bug: Value Format in Table Report Visualization Col and Row Subtotal Issue

### DIFF
--- a/src/vis_primitives.js
+++ b/src/vis_primitives.js
@@ -1,3 +1,4 @@
+import SSF from 'ssf';
 /**
  * Returns an array of given length, all populated with same value
  * Convenience function e.g. to initialise arrays of zeroes or nulls.
@@ -20,16 +21,18 @@ class ModelField {
     this.view = queryResponseField.view_label || '';
     this.label = queryResponseField.label_short || queryResponseField.label;
     this.is_numeric =
-      typeof queryResponseField.is_numeric !== 'undefined'
-        ? queryResponseField.is_numeric
-        : false;
+    typeof queryResponseField.is_numeric !== 'undefined'
+    ? queryResponseField.is_numeric
+    : false;
     this.is_array = ['list', 'number_list', 'location', 'tier'].includes(
       queryResponseField.type
     );
     this.value_format = queryResponseField.value_format
-      ? queryResponseField.value_format
-      : '';
+    ? queryResponseField.value_format
+    : '';
 
+    console.log('incoming value_format from query', queryResponseField.value_format)
+    console.log('set value_format', this.value_format)
     this.geo_type = '';
     if (
       queryResponseField.type === 'location' ||

--- a/src/vis_primitives.js
+++ b/src/vis_primitives.js
@@ -31,8 +31,6 @@ class ModelField {
     ? queryResponseField.value_format
     : '';
 
-    console.log('incoming value_format from query', queryResponseField.value_format)
-    console.log('set value_format', this.value_format)
     this.geo_type = '';
     if (
       queryResponseField.type === 'location' ||

--- a/src/vis_table_plugin.js
+++ b/src/vis_table_plugin.js
@@ -1013,11 +1013,25 @@ class VisPluginTableModel {
     this.columns.push(column);
   }
 
+/** Manage formatting in one place
+ * @param {*} valueFormat
+ * @param {*} value
+*/
+  formatCellValue(valueFormat, value) {
+    if([null, undefined, ""].includes(valueFormat)){
+      console.log('valueformat was not defined')
+      valueFormat = '#,##0'
+    }
+    let return_val = SSF.format(valueFormat, value)
+    console.log({valueFormat, value, return_val})
+    return return_val
+  }
   /**
    * this.subtotals_data
    * @param {*} queryResponse
    */
   checkSubtotalsData(queryResponse) {
+    console.log('in check subtotals', {queryResponse})
     if (
       typeof queryResponse.subtotals_data[this.addSubtotalDepth] !== 'undefined'
     ) {
@@ -1071,7 +1085,7 @@ class VisPluginTableModel {
                   column.modelField.value_format === ''
                     ? cell.value.toString()
                     : unit +
-                      SSF.format(column.modelField.value_format, cell.value);
+                      this.formatCellValue(column.modelField.value_format, cell.value);
               }
             }
           });
@@ -1129,7 +1143,7 @@ class VisPluginTableModel {
           cell.rendered =
             column.modelField.value_format === ''
               ? cell.value.toString()
-              : unit + SSF.format(column.modelField.value_format, cell.value);
+              : unit + this.formatCellValue(column.modelField.value_format, cell.value);
         }
 
         if (column.modelField.is_turtle) {
@@ -1279,7 +1293,7 @@ class VisPluginTableModel {
             column.modelField.value_format === ''
               ? cellValue.value.toString()
               : unit +
-                SSF.format(column.modelField.value_format, cellValue.value);
+                this.formatCellValue(column.modelField.value_format, cellValue.value);
         }
 
         totalsRow.data[column.id] = cellValue;
@@ -1354,10 +1368,10 @@ class VisPluginTableModel {
           var formatted_value =
             column.modelField.value_format === ''
               ? othersValue.toString()
-              : SSF.format(column.modelField.value_format, othersValue);
+              : this.formatCellValue(column.modelField.value_format, othersValue);
           othersRow.data[column.id] = new DataCell({
             value: othersValue,
-            rendered: formatted_value,
+            rendered: this.formatCellValue(column.modelField.value_format, othersValue),
             cell_style: othersStyle,
             align: column.modelField.is_numeric ? 'right' : 'left',
             colid: column.id,
@@ -1618,8 +1632,10 @@ class VisPluginTableModel {
                   ? subtotal_value.toString()
                   : subtotal_value != 0
                   ? unit +
-                    SSF.format(column.modelField.value_format, subtotal_value)
+                    this.formatCellValue(column.modelField.value_format, subtotal_value)
                   : 0;
+                  // console.log('format5?',this.formatCellValue(column.modelField.value_format, subtotal_value), 'value_format:', column.modelField.value_format, {rendered, subtotal_value})
+
             }
             if (column.modelField.calculation_type === 'string') {
               subtotal_value = '';
@@ -1628,7 +1644,7 @@ class VisPluginTableModel {
 
             var cell = new DataCell({
               value: subtotal_value,
-              rendered: rendered,
+              rendered: this.formatCellValue(column.modelField.value_format, subtotal_value),
               cell_style: cell_style,
               align: align,
               colid: column.id,
@@ -1829,10 +1845,11 @@ class VisPluginTableModel {
           rendered:
             subtotalColumn.modelField.value_format === ''
               ? subtotal_value.toString()
-              : SSF.format(
+              : this.formatCellValue(
                   subtotalColumn.modelField.value_format,
                   subtotal_value
                 ),
+          // rendered: this.formatCellValue(subtotalColumn.modelField.value_format, subtotal_value),
           cell_style: cell_style,
           colid: subtotalColumn.id,
           rowid: row.id,
@@ -1859,16 +1876,19 @@ class VisPluginTableModel {
       var baseline_value = row.data[baseline.id].value;
       var comparison_value = row.data[comparison.id].value;
       if (calc === 'absolute') {
+        let render_value = this.formatCellValue(value_format, baseline_value - comparison_value);
         var cell = new DataCell({
           value: baseline_value - comparison_value,
           rendered:
             value_format === ''
               ? (baseline_value - comparison_value).toString()
-              : SSF.format(value_format, baseline_value - comparison_value),
+              : render_value,
           cell_style: ['numeric', 'measure', 'variance', 'varianceAbsolute'],
           colid: id,
           rowid: row.id,
-        });
+        })
+        // console.log('in if', this.formatCellValue(value_format, baseline_value - comparison_value), {render_value})
+        ;
       } else {
         var value =
           (baseline_value - comparison_value) / Math.abs(comparison_value);
@@ -1883,11 +1903,12 @@ class VisPluginTableModel {
         } else {
           var cell = new DataCell({
             value: value,
-            rendered: SSF.format('#0.00%', value),
+            rendered: this.formatCellValue('#0.00%', value),
             cell_style: ['numeric', 'measure', 'variance', 'variancePercent'],
             colid: id,
             rowid: row.id,
           });
+          // console.log('in else',this.formatCellValue('#0.00%', value) )
         }
       }
       if (row.type == 'total' || row.type == 'subtotal') {

--- a/src/vis_table_plugin.js
+++ b/src/vis_table_plugin.js
@@ -1019,11 +1019,9 @@ class VisPluginTableModel {
 */
   formatCellValue(valueFormat, value) {
     if([null, undefined, ""].includes(valueFormat)){
-      console.log('valueformat was not defined')
       valueFormat = '#,##0'
     }
     let return_val = SSF.format(valueFormat, value)
-    console.log({valueFormat, value, return_val})
     return return_val
   }
   /**
@@ -1031,7 +1029,6 @@ class VisPluginTableModel {
    * @param {*} queryResponse
    */
   checkSubtotalsData(queryResponse) {
-    console.log('in check subtotals', {queryResponse})
     if (
       typeof queryResponse.subtotals_data[this.addSubtotalDepth] !== 'undefined'
     ) {
@@ -1634,8 +1631,6 @@ class VisPluginTableModel {
                   ? unit +
                     this.formatCellValue(column.modelField.value_format, subtotal_value)
                   : 0;
-                  // console.log('format5?',this.formatCellValue(column.modelField.value_format, subtotal_value), 'value_format:', column.modelField.value_format, {rendered, subtotal_value})
-
             }
             if (column.modelField.calculation_type === 'string') {
               subtotal_value = '';
@@ -1887,8 +1882,6 @@ class VisPluginTableModel {
           colid: id,
           rowid: row.id,
         })
-        // console.log('in if', this.formatCellValue(value_format, baseline_value - comparison_value), {render_value})
-        ;
       } else {
         var value =
           (baseline_value - comparison_value) / Math.abs(comparison_value);
@@ -1908,7 +1901,6 @@ class VisPluginTableModel {
             colid: id,
             rowid: row.id,
           });
-          // console.log('in else',this.formatCellValue('#0.00%', value) )
         }
       }
       if (row.type == 'total' || row.type == 'subtotal') {


### PR DESCRIPTION
When using a pivot table with 2–3 levels and enabling both COL and ROW SUBTOTALS in edit settings, the value format is not being respected in the subtotal rows.