### PR TITLE
fix(bug): Value format column subtotal issue

### DIFF
--- a/src/vis_table_plugin.js
+++ b/src/vis_table_plugin.js
@@ -1596,7 +1596,7 @@ class VisPluginTableModel {
             this.data.forEach(data_row => {
               if (data_row.type == 'line_item' && data_row.sort[1].value == s) {
                 // data_row.sort[1].value == s checks whether its part of the current subtotal group
-                var value = data_row.data[column.id].value;
+                var value = this.formatCellValue(column.modelField.value_format, data_row.data[column.id].value)
                 if (Number.isFinite(value)) {
                   subtotal_value += value;
                   subtotal_items++;
@@ -1837,14 +1837,7 @@ class VisPluginTableModel {
         });
         row.data[subtotalColumn.id] = new DataCell({
           value: subtotal_value,
-          rendered:
-            subtotalColumn.modelField.value_format === ''
-              ? subtotal_value.toString()
-              : this.formatCellValue(
-                  subtotalColumn.modelField.value_format,
-                  subtotal_value
-                ),
-          // rendered: this.formatCellValue(subtotalColumn.modelField.value_format, subtotal_value),
+          rendered:this.formatCellValue(subtotalColumn.modelField.value_format, subtotal_value),
           cell_style: cell_style,
           colid: subtotalColumn.id,
           rowid: row.id,


### PR DESCRIPTION
When using a pivot table with 2–3 levels and enabling both COL and ROW SUBTOTALS in edit settings, the value format is not being respected in the subtotal columns. Related to #64 